### PR TITLE
トーク用パラメータを英語に設定 (#16)

### DIFF
--- a/ceviopy/cevio.py
+++ b/ceviopy/cevio.py
@@ -141,6 +141,10 @@ class Cevio:
         Args:
             talktype (str): コンディションの指定
             value (int): コンディションの値
+
+        Raises :
+            CevioException : CeVIOが起動していない場合の例外
+            ValueError : 値が数値でない場合
         """
         default_params = self.get_talk_params()
         trans_dict = {
@@ -151,25 +155,30 @@ class Cevio:
             "声質":"Alpha"
         }
         changed_params = {}
+
+        # コンディションに和名が含まれている場合
+        if (talktype in trans_dict.keys()):
+            # talkTypeを英語名に上書き
+            talktype = trans_dict[talktype]
         # コンディション一覧に含まれているもののみ
-        if (talktype in trans_dict):
+        if (talktype in trans_dict.values()):
             # 整数値のみ
             if (self._is_int(value)):
                 if (int(value) >= 0 and int(value) <= 100):
-                    changed_params[trans_dict[talktype]] = int(value)
-                    self._change_talk_param(trans_dict[talktype], changed_params[trans_dict[talktype]])
+                    changed_params[talktype] = int(value)
+                    self._change_talk_param(talktype, changed_params[talktype])
                 else:
                     print("value must be an integer between 0 and 100.")
             else:
                 print("value must be an integer between 0 and 100.")
         else:
-            print(f"Condition is not included in the list. Please select from the following: [{','.join(trans_dict.keys())}]")
+            print(f"Condition is not included in the list. Please select from the following: [{','.join(trans_dict.values())}]")
 
         # パラメータ差分表示
         for key in changed_params.keys():
             if (default_params[key] != changed_params[key]):
                 print(f"{key}: {default_params[key]} -> {changed_params[key]}")
-    
+
     def _is_int(self, value):
         try:
             # int型かを判定

--- a/module/cevio.py
+++ b/module/cevio.py
@@ -141,6 +141,10 @@ class Cevio:
         Args:
             talktype (str): コンディションの指定
             value (int): コンディションの値
+
+        Raises :
+            CevioException : CeVIOが起動していない場合の例外
+            ValueError : 値が数値でない場合
         """
         default_params = self.get_talk_params()
         trans_dict = {
@@ -151,19 +155,24 @@ class Cevio:
             "声質":"Alpha"
         }
         changed_params = {}
+
+        # コンディションに和名が含まれている場合
+        if (talktype in trans_dict.keys()):
+            # talkTypeを英語名に上書き
+            talktype = trans_dict[talktype]
         # コンディション一覧に含まれているもののみ
-        if (talktype in trans_dict):
+        if (talktype in trans_dict.values()):
             # 整数値のみ
             if (self._is_int(value)):
                 if (int(value) >= 0 and int(value) <= 100):
-                    changed_params[trans_dict[talktype]] = int(value)
-                    self._change_talk_param(trans_dict[talktype], changed_params[trans_dict[talktype]])
+                    changed_params[talktype] = int(value)
+                    self._change_talk_param(talktype, changed_params[talktype])
                 else:
                     print("value must be an integer between 0 and 100.")
             else:
                 print("value must be an integer between 0 and 100.")
         else:
-            print(f"Condition is not included in the list. Please select from the following: [{','.join(trans_dict.keys())}]")
+            print(f"Condition is not included in the list. Please select from the following: [{','.join(trans_dict.values())}]")
 
         # パラメータ差分表示
         for key in changed_params.keys():

--- a/readme.md
+++ b/readme.md
@@ -156,20 +156,27 @@ Python上でCeVIO AIのトーク機能を利用するモジュール群です。
 
         ```py
         # トークの設定
+        talk.set_talk_param("Speed", 50)
+        ## > Speed: 30 -> 50
+        # 日本語可(以下の通り変換)
+        ## "大きさ" -> "Volume"
+        ## "速さ" -> "Speed"
+        ## "高さ" -> "Tone"
+        ## "抑揚" -> "ToneScale"
+        ## "声質" -> "Alpha"
         talk.set_talk_param("速さ", 30)
         ## > Speed: 50 -> 30
 
         # 存在しない値を入力した場合エラー
-        talk.set_talk_param("速さ", 4000) 
+        talk.set_talk_param("Speed", 4000) 
         ## > valueは0～100の整数値を渡してください
 
         # 存在しないパラメータを入力した場合エラー
-        talk.set_talk_param("素早さ", 10)  
-        ## > Conditionが一覧に含まれていません。以下から選択してください。
-        ## > 大きさ,速さ,高さ,抑揚,声質
+        talk.set_talk_param("Speedy", 10)  
+        ## > Condition is not included in the list. Please select from the following: [Volume,Speed,Tone,ToneScale,Alpha]
 
         # dict形式で渡す場合、「set_talk_params」を使用
-        talk.set_talk_params({"速さ": 60, "大きさ": 60})
+        talk.set_talk_params({"Speed": 60, "Volume": 60})
         ## > Speed: 50 -> 60
         ## > Volume: 50 -> 60
         ```


### PR DESCRIPTION
- トーク用パラメータを英語に設定
- set_talk_paramを英語用のフォーマットに合わせたうえで、過去に日本語で設定したユーザ向けに日本語処理を残す
- 重要な変更であるため、更新対象とならないmodule側も更新する
  - ただし、_ccs, _aiは更新しない